### PR TITLE
Fix output file location in XTBProfile.run() when specifying `directory` parameter

### DIFF
--- a/src/xtb_ase/calculator.py
+++ b/src/xtb_ase/calculator.py
@@ -74,7 +74,7 @@ class XTBProfile:
         """
         cmd = self.argv + ["--input", input_filename, geom_filename, "--json"]
         cmd = [str(arg) for arg in cmd]
-        with open(output_filename, "w") as fd:
+        with open(directory / output_filename, "w") as fd:
             check_call(cmd, stdout=fd, cwd=directory)
 
 


### PR DESCRIPTION
This PR addresses an issue where the `run()` method in the `XTBProfile` class was incorrectly handling the output file location when specifying `directory` parameter. It was opening the output file in the current working directory instead of the specified `directory`. This led to an error in the `read_results()` method in the `_XTBTemplate` class.

**Change made:**
- Change the path to the output file from `output_filename` to `directory / output_filename` to ensure the output file is created in the directory specified by the `directory` parameter